### PR TITLE
[portenta-tutorials] deploy to cdn GHA

### DIFF
--- a/.github/workflows/workflow-prod.yaml
+++ b/.github/workflows/workflow-prod.yaml
@@ -1,21 +1,17 @@
-name: Deploy tutorials (dev)
+name: Release tutorials (prod)
 
-on: 
-  repository_dispatch:
-    types: deploy
+on:
   push:
-    branches:
-      # - master
-      - fstasi/portenta-tutorials
+    tags:
+    - 'v*'
 
 env:
   AWS_REGION: 'us-west-1'
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -29,12 +25,20 @@ jobs:
       with:
         args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate
       env:
-        AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
+        AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME_PROD }}
         SOURCE_DIR: 'content/tutorials'
         DEST_DIR: 'content/tutorials'
 
     - name: Invalidate CloudFront distribution
       uses: chetan/invalidate-cloudfront-action@v1.0
       env:
-        DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+        DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD }}
         PATHS: '/content/tutorials/*'
+
+    - name: Purge cache
+      uses: jakejarvis/cloudflare-purge-action@master
+      env:
+        PURGE_URLS: '["https://www.arduino.cc/pro/"]'
+        CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
+        CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
+        CLOUDFLARE_KEY: ${{ secrets.CLOUDFLARE_KEY }}

--- a/.github/workflows/workflow-prod.yaml
+++ b/.github/workflows/workflow-prod.yaml
@@ -19,11 +19,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    
+
+    - name: S3 Sync (misc files)
+      uses: jakejarvis/s3-sync-action@v0.5.0
+      with:
+        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*.md' --cache-control max-age=0,no-cache,no-store,must-revalidate
+      env:
+        AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME_PROD }}
+        SOURCE_DIR: 'content/tutorials'
+        DEST_DIR: 'content/tutorials'
+
     - name: S3 Sync (Markdown files)
       uses: jakejarvis/s3-sync-action@v0.5.0
       with:
-        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate
+        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*' --include '*.md' --content-type 'text/markdown' --cache-control max-age=0,no-cache,no-store,must-revalidate
       env:
         AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME_PROD }}
         SOURCE_DIR: 'content/tutorials'

--- a/.github/workflows/workflow-prod.yaml
+++ b/.github/workflows/workflow-prod.yaml
@@ -20,34 +20,37 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: S3 Sync (misc files)
-      uses: jakejarvis/s3-sync-action@v0.5.0
-      with:
-        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*.md' --cache-control max-age=0,no-cache,no-store,must-revalidate
-      env:
-        AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME_PROD }}
-        SOURCE_DIR: 'content/tutorials'
-        DEST_DIR: 'content/tutorials'
 
-    - name: S3 Sync (Markdown files)
-      uses: jakejarvis/s3-sync-action@v0.5.0
-      with:
-        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*' --include '*.md' --content-type 'text/markdown' --cache-control max-age=0,no-cache,no-store,must-revalidate
-      env:
-        AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME_PROD }}
-        SOURCE_DIR: 'content/tutorials'
-        DEST_DIR: 'content/tutorials'
+    - name: S3 sync (misc files)
+      run: |
+        aws s3 sync \
+          content/tutorials \
+          s3://${{ secrets.S3_BUCKET_NAME_PROD }}/content/tutorials/ \
+          --no-progress \
+          --acl public-read \
+          --follow-symlinks \
+          --delete \
+          --metadata-directive REPLACE \
+          --exclude '*.md' \
+          --cache-control max-age=0,no-cache,no-store,must-revalidate
+
+    - name: S3 sync (Markdown files)
+      run: |
+        aws s3 sync \
+          content/tutorials \
+          s3://${{ secrets.S3_BUCKET_NAME_PROD }}/content/tutorials/ \
+          --no-progress \
+          --acl public-read \
+          --follow-symlinks \
+          --delete \
+          --metadata-directive REPLACE \
+          --exclude '*' \
+          --include '*.md' \
+          --content-type 'text/markdown' \
+          --cache-control max-age=0,no-cache,no-store,must-revalidate
 
     - name: Invalidate CloudFront distribution
-      uses: chetan/invalidate-cloudfront-action@v1.0
-      env:
-        DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD }}
-        PATHS: '/content/tutorials/*'
-
-    - name: Purge cache
-      uses: jakejarvis/cloudflare-purge-action@master
-      env:
-        PURGE_URLS: '["https://www.arduino.cc/pro/"]'
-        CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
-        CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
-        CLOUDFLARE_KEY: ${{ secrets.CLOUDFLARE_KEY }}
+      run: |
+        aws cloudfront create-invalidation \
+          --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD }}" \
+          --paths '/content/tutorials/*'

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,6 +1,8 @@
 name: Deploy tutorial
 
 on: 
+  repository_dispatch:
+    types: deploy
   push:
     branches:
       # - master

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: S3 Sync (misc files)
       uses: jakejarvis/s3-sync-action@v0.5.0
       with:
-        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*.md' --cache-control max-age=31536000
+        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*.md' --cache-control max-age=0,no-cache,no-store,must-revalidate
       env:
         AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
         SOURCE_DIR: 'content/tutorials'

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,0 +1,37 @@
+name: Deploy tutorial
+
+on: 
+  push:
+    branches:
+      - master
+
+env:
+  AWS_REGION: 'us-west-1' # optional: defaults to us-east-1
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node_version: [12]
+
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: S3 Sync (Markdown files)
+      uses: jakejarvis/s3-sync-action@v0.5.0
+      with:
+        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate
+      env:
+        AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
+        SOURCE_DIR: 'content/tutorials'
+        DEST_DIR: 'content/tutorials'
+
+    - name: Invalidate CloudFront distribution
+      uses: chetan/invalidate-cloudfront-action@v1.0
+      env:
+        DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+        PATHS: '/content/tutorials/*'

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -24,10 +24,19 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     
+    - name: S3 Sync (misc files)
+      uses: jakejarvis/s3-sync-action@v0.5.0
+      with:
+        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*.md' --cache-control max-age=31536000
+      env:
+        AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
+        SOURCE_DIR: 'content/tutorials'
+        DEST_DIR: 'content/tutorials'
+
     - name: S3 Sync (Markdown files)
       uses: jakejarvis/s3-sync-action@v0.5.0
       with:
-        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate
+        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*' --include '*.md' --content-type 'text/markdown' --cache-control max-age=0,no-cache,no-store,must-revalidate
       env:
         AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
         SOURCE_DIR: 'content/tutorials'

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -14,8 +14,8 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 jobs:
-  build:
 
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -24,26 +24,36 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     
-    - name: S3 Sync (misc files)
-      uses: jakejarvis/s3-sync-action@v0.5.0
-      with:
-        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*.md' --cache-control max-age=0,no-cache,no-store,must-revalidate
-      env:
-        AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
-        SOURCE_DIR: 'content/tutorials'
-        DEST_DIR: 'content/tutorials'
+    - name: S3 sync (misc files)
+      run: |
+        aws s3 sync \
+          content/tutorials \
+          s3://${{ secrets.S3_BUCKET_NAME }}/content/tutorials/ \
+          --no-progress \
+          --acl public-read \
+          --follow-symlinks \
+          --delete \
+          --metadata-directive REPLACE \
+          --exclude '*.md' \
+          --cache-control max-age=0,no-cache,no-store,must-revalidate
 
-    - name: S3 Sync (Markdown files)
-      uses: jakejarvis/s3-sync-action@v0.5.0
-      with:
-        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*' --include '*.md' --content-type 'text/markdown' --cache-control max-age=0,no-cache,no-store,must-revalidate
-      env:
-        AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
-        SOURCE_DIR: 'content/tutorials'
-        DEST_DIR: 'content/tutorials'
+    - name: S3 sync (Markdown files)
+      run: |
+        aws s3 sync \
+          content/tutorials \
+          s3://${{ secrets.S3_BUCKET_NAME }}/content/tutorials/ \
+          --no-progress \
+          --acl public-read \
+          --follow-symlinks \
+          --delete \
+          --metadata-directive REPLACE \
+          --exclude '*' \
+          --include '*.md' \
+          --content-type 'text/markdown' \
+          --cache-control max-age=0,no-cache,no-store,must-revalidate
 
     - name: Invalidate CloudFront distribution
-      uses: chetan/invalidate-cloudfront-action@v1.0
-      env:
-        DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-        PATHS: '/content/tutorials/*'
+      run: |
+        aws cloudfront create-invalidation \
+          --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
+          --paths '/content/tutorials/*'

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -3,7 +3,8 @@ name: Deploy tutorial
 on: 
   push:
     branches:
-      - master
+      # - master
+      - fstasi/portenta-tutorials
 
 env:
   AWS_REGION: 'us-west-1' # optional: defaults to us-east-1


### PR DESCRIPTION
this GH action enables auto deploy of the markdown files to s3 and invalidates the cdn cache.