### PR TITLE
Remove 3rd party Actions

### DIFF
--- a/.github/workflows/workflow-prod.yaml
+++ b/.github/workflows/workflow-prod.yaml
@@ -50,15 +50,7 @@ jobs:
           --cache-control max-age=0,no-cache,no-store,must-revalidate
 
     - name: Invalidate CloudFront distribution
-      uses: chetan/invalidate-cloudfront-action@v1.0
-      env:
-        DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD }}
-        PATHS: '/content/tutorials/*'
-
-    - name: Purge cache
-      uses: jakejarvis/cloudflare-purge-action@master
-      env:
-        PURGE_URLS: '["https://www.arduino.cc/pro/"]'
-        CLOUDFLARE_ZONE: ${{ secrets.CLOUDFLARE_ZONE }}
-        CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
-        CLOUDFLARE_KEY: ${{ secrets.CLOUDFLARE_KEY }}
+      run: |
+        aws cloudfront create-invalidation \
+          --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD }}" \
+          --paths '/content/tutorials/*'

--- a/.github/workflows/workflow-prod.yaml
+++ b/.github/workflows/workflow-prod.yaml
@@ -20,23 +20,34 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: S3 Sync (misc files)
-      uses: jakejarvis/s3-sync-action@v0.5.0
-      with:
-        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*.md' --cache-control max-age=0,no-cache,no-store,must-revalidate
-      env:
-        AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME_PROD }}
-        SOURCE_DIR: 'content/tutorials'
-        DEST_DIR: 'content/tutorials'
 
-    - name: S3 Sync (Markdown files)
-      uses: jakejarvis/s3-sync-action@v0.5.0
-      with:
-        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*' --include '*.md' --content-type 'text/markdown' --cache-control max-age=0,no-cache,no-store,must-revalidate
-      env:
-        AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME_PROD }}
-        SOURCE_DIR: 'content/tutorials'
-        DEST_DIR: 'content/tutorials'
+    - name: S3 sync (misc files)
+      run: |
+        aws s3 sync \
+          content/tutorials \
+          s3://${{ secrets.S3_BUCKET_NAME_PROD }}/content/tutorials/ \
+          --no-progress \
+          --acl public-read \
+          --follow-symlinks \
+          --delete \
+          --metadata-directive REPLACE \
+          --exclude '*.md' \
+          --cache-control max-age=0,no-cache,no-store,must-revalidate
+
+    - name: S3 sync (Markdown files)
+      run: |
+        aws s3 sync \
+          content/tutorials \
+          s3://${{ secrets.S3_BUCKET_NAME_PROD }}/content/tutorials/ \
+          --no-progress \
+          --acl public-read \
+          --follow-symlinks \
+          --delete \
+          --metadata-directive REPLACE \
+          --exclude '*' \
+          --include '*.md' \
+          --content-type 'text/markdown' \
+          --cache-control max-age=0,no-cache,no-store,must-revalidate
 
     - name: Invalidate CloudFront distribution
       uses: chetan/invalidate-cloudfront-action@v1.0

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -6,7 +6,8 @@ on:
   push:
     branches:
       # - master
-      - fstasi/portenta-tutorials
+      # - fstasi/portenta-tutorials
+      - zmoog/remote-3rd-party-actions
 
 env:
   AWS_REGION: 'us-west-1'
@@ -24,23 +25,33 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     
-    - name: S3 Sync (misc files)
-      uses: jakejarvis/s3-sync-action@v0.5.0
-      with:
-        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*.md' --cache-control max-age=0,no-cache,no-store,must-revalidate
-      env:
-        AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
-        SOURCE_DIR: 'content/tutorials'
-        DEST_DIR: 'content/tutorials'
+    - name: S3 sync (misc files)
+      run: |
+        aws s3 sync \
+          content/tutorials \
+          s3://${{ secrets.S3_BUCKET_NAME }}/content/tutorials/ \
+          --no-progress \
+          --acl public-read \
+          --follow-symlinks \
+          --delete \
+          --metadata-directive REPLACE \
+          --exclude '*.md' \
+          --cache-control max-age=0,no-cache,no-store,must-revalidate
 
-    - name: S3 Sync (Markdown files)
-      uses: jakejarvis/s3-sync-action@v0.5.0
-      with:
-        args: --acl public-read --follow-symlinks --delete --metadata-directive REPLACE --exclude '*' --include '*.md' --content-type 'text/markdown' --cache-control max-age=0,no-cache,no-store,must-revalidate
-      env:
-        AWS_S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
-        SOURCE_DIR: 'content/tutorials'
-        DEST_DIR: 'content/tutorials'
+    - name: S3 sync (Markdown files)
+      run: |
+        aws s3 sync \
+          content/tutorials \
+          s3://${{ secrets.S3_BUCKET_NAME }}/content/tutorials/ \
+          --no-progress \
+          --acl public-read \
+          --follow-symlinks \
+          --delete \
+          --metadata-directive REPLACE \
+          --exclude '*' \
+          --include '*.md' \
+          --content-type 'text/markdown' \
+          --cache-control max-age=0,no-cache,no-store,must-revalidate
 
     - name: Invalidate CloudFront distribution
       uses: chetan/invalidate-cloudfront-action@v1.0

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -6,8 +6,7 @@ on:
   push:
     branches:
       # - master
-      # - fstasi/portenta-tutorials
-      - zmoog/remote-3rd-party-actions
+      - fstasi/portenta-tutorials
 
 env:
   AWS_REGION: 'us-west-1'

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -54,7 +54,7 @@ jobs:
           --cache-control max-age=0,no-cache,no-store,must-revalidate
 
     - name: Invalidate CloudFront distribution
-      uses: chetan/invalidate-cloudfront-action@v1.0
-      env:
-        DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-        PATHS: '/content/tutorials/*'
+      run: |
+        aws cloudfront create-invalidation \
+          --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
+          --paths '/content/tutorials/*'


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
The 3rd party Actions used for the S3 sync and CloudFront invalidation are just thin wrappers on AWS CLI and can be easily replaced with the AWS CLI.

Benefits:
* No Docker image downloads
* Faster execution
* No potential security risks (3rd party code can be replaced anytime).

### Change description
<!-- What does your code do? -->

Replace `jakejarvis/s3-sync-action` and `chetan/invalidate-cloudfront-action` Actions with the equivalent command using `aws cli`

