### PR TITLE
Remove superfluous pinMode commands

### DIFF
--- a/content/tutorials/portenta-h7/por-ard-ap/content.md
+++ b/content/tutorials/portenta-h7/por-ard-ap/content.md
@@ -57,10 +57,6 @@ void setup() {
   
   Serial.println("Access Point Web Server");
 
-  pinMode(LEDR,OUTPUT);
-  pinMode(LEDG,OUTPUT);
-  pinMode(LEDB,OUTPUT); 
-
   // by default the local IP address of will be 192.168.3.1
   // you can override it with the following:
   // WiFi.config(IPAddress(10, 0, 0, 1));


### PR DESCRIPTION
From my observations on Portenta the pin mode for the built-in LEDs is output by default and hence they don't need to be set. Doing so causes them to turn on as they seem to get pulled low. 
@facchinm What's your opinion? Should we remove those pinMode commands from the example or turn them off manually  using
```
  digitalWrite(LEDR, HIGH);
  digitalWrite(LEDG, HIGH);
  digitalWrite(LEDB, HIGH);
```
or fix this in the core?